### PR TITLE
Default dont change position, update if change

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -96,12 +96,12 @@ class Map extends Component {
         break;
 
       default:
-        newPlayerPosition = null;
+        newPlayerPosition = oldPlayerPosition;
     }
 
     GetAgentWithId('a0', newAgents).state.position = newPlayerPosition;
 
-    if (newPlayerPosition !== null) {
+    if (newPlayerPosition !== oldPlayerPosition) {
       this.setState(state => ({
         agents: newAgents,
         playerOn: this.state.tilesStates[newPlayerPosition[1]][


### PR DESCRIPTION
 connected to #12

Default case of switch simply sets new position to old position.

I need to make sure the other agents' positions are not changed when this happens. This is because I also made it so that the game's state is only updated if the position does change.

If I let the agents change their position while the player stays stationary (basically a wait a turn feature) then the state won't update, cause the player position hasn't changed, and when it does change the agents will all suddenly jump to their new positions, likely more than a tile away.